### PR TITLE
Add synchronized to getInstance method

### DIFF
--- a/_posts/2012-05-21-correctly-managing-your-sqlite-database.md
+++ b/_posts/2012-05-21-correctly-managing-your-sqlite-database.md
@@ -51,7 +51,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
   private static final String DATABASE_TABLE = "table_name";
   private static final int DATABASE_VERSION = 1;
 
-  public static DatabaseHelper getInstance(Context context) {
+  public static synchronized DatabaseHelper getInstance(Context context) {
      
     // Use the application context, which will ensure that you 
     // don't accidentally leak an Activity's context.


### PR DESCRIPTION
Without the `synchronized` keyword, I feel the statement :

 > always use `DatabaseHelper.getInstance(context)`, as it guarantees that only one database helper will exist across the entire application's lifecycle" 

is false or at least misleading, due to thread safety concerns. 

I'm a bit new to the "singleton pattern" as my major was physics not computer science, and after reading in the API documentation that *There is normally no need to subclass Application. In most situation, static singletons can provide the same functionality in a more modular way.*, I've been trying to move a bunch of code out of Application and into singletons. 

One of the objects has a built-in `SQLiteDatabase`, so having a single instance across all threads is a big issue (it's a port of a python library to java, so for maintainability we can't really wrap the db itself in a ContentProvider), and I was having trouble finding a kind of "standard" way of implementing the Singleton pattern on Android, recommended by Google. I almost used your pattern here, which another project member mentioned isn't a very good singleton pattern.

e.g. I've since found the following, [written by Dianne Hackborn](https://groups.google.com/forum/#!topic/android-developers/2i82mjoM46M):


> This is my preferred approach for implementing a singleton that needs a Context:

    static final Object sLock = new Object();
    static MySingleton sInstance;

    static MySingleton getInstance(Application app) {
        synchronized (sLock) {
            if (sInstance == null) {
                sInstance = new MySingleton(app);
            }
            return sInstance;
        }
    }

Since your blog is called Android design patterns, and you refer to this as the singleton pattern, it would be good if you could use a more standard thread safe one (e.g. see the above link, or [here](http://stackoverflow.com/questions/70689/what-is-an-efficient-way-to-implement-a-singleton-pattern-in-java)). Or even better, write a whole post about the singleton pattern, as this is a pretty interesting issue with most of the Android specific information scattered around various unofficial places.